### PR TITLE
Remove hot file before building

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -141,13 +141,13 @@ function jigsawBinPath() {
 /**
  * Spawns a child process to run "jigsaw build" with the proper environment.
  */
-function spawnJigsawBuild(hotFile: string, quiet = true): Promise<void> {
+function spawnJigsawBuild(hotFile: null | string = null, quiet = true): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         const bin = jigsawBinPath();
         const envArg = process.env.NODE_ENV === 'development' ? 'local' : process.env.NODE_ENV;
 
         // Remove the hot file when building for non-local environments
-        if (envArg !== "local" && existsSync(hotFile)) {
+        if (hotFile && existsSync(hotFile)) {
             try {
                 unlinkSync(hotFile);
             } catch (e) {
@@ -255,7 +255,7 @@ function resolveJigsawPlugin(pluginConfig: DefinedPluginConfig): JigsawPlugin {
 
         configureServer(server) {
             // Trigger the initial build on server start.
-            spawnJigsawBuild(pluginConfig.hotFile)
+            spawnJigsawBuild()
                 .then(() => {
                     server.config.logger.info(`\n  ${colors.green('Initial Jigsaw build completed.')}`);
                 })
@@ -326,7 +326,7 @@ function resolveJigsawWatcherPlugin(pluginConfig: DefinedPluginConfig): JigsawPl
                     if (shouldReload(path)) {
                         const start = performance.now();
 
-                        await JigsawQueue.enqueue(() => spawnJigsawBuild(pluginConfig.hotFile));
+                        await JigsawQueue.enqueue(() => spawnJigsawBuild());
 
                         const end = performance.now();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,8 +146,8 @@ function spawnJigsawBuild(hotFile: string, quiet = true): Promise<void> {
         const bin = jigsawBinPath();
         const envArg = process.env.NODE_ENV === 'development' ? 'local' : process.env.NODE_ENV;
 
-        // Remove the hotFile if it exists
-        if (process.env.NODE_ENV !== "development" && existsSync(hotFile)) {
+        // Remove the hot file when building for non-local environments
+        if (envArg !== "local" && existsSync(hotFile)) {
             try {
                 unlinkSync(hotFile);
             } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ function spawnJigsawBuild(hotFile: string, quiet = true): Promise<void> {
         const envArg = process.env.NODE_ENV === 'development' ? 'local' : process.env.NODE_ENV;
 
         // Remove the hotFile if it exists
-        if (existsSync(hotFile)) {
+        if (process.env.NODE_ENV !== "development" && existsSync(hotFile)) {
             try {
                 unlinkSync(hotFile);
             } catch (e) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { spawn } from 'child_process';
 import { resolve, relative, join } from 'path';
 import { fileURLToPath } from 'url';
@@ -141,10 +141,20 @@ function jigsawBinPath() {
 /**
  * Spawns a child process to run "jigsaw build" with the proper environment.
  */
-function spawnJigsawBuild(quiet = true): Promise<void> {
+function spawnJigsawBuild(hotFile: string, quiet = true): Promise<void> {
     return new Promise<void>((resolve, reject) => {
         const bin = jigsawBinPath();
         const envArg = process.env.NODE_ENV === 'development' ? 'local' : process.env.NODE_ENV;
+
+        // Remove the hotFile if it exists
+        if (existsSync(hotFile)) {
+            try {
+                unlinkSync(hotFile);
+            } catch (e) {
+                console.warn(`Could not remove hot file at ${hotFile}:`, e);
+            }
+        }
+
         const child = spawn(bin, [`build ${quiet ? '-q' : ''}`, envArg!], { stdio: 'inherit', shell: true });
         child.on('exit', (code) => {
             if (Number(code) > 0) {
@@ -245,7 +255,7 @@ function resolveJigsawPlugin(pluginConfig: DefinedPluginConfig): JigsawPlugin {
 
         configureServer(server) {
             // Trigger the initial build on server start.
-            spawnJigsawBuild()
+            spawnJigsawBuild(pluginConfig.hotFile)
                 .then(() => {
                     server.config.logger.info(`\n  ${colors.green('Initial Jigsaw build completed.')}`);
                 })
@@ -283,7 +293,7 @@ function resolveJigsawPlugin(pluginConfig: DefinedPluginConfig): JigsawPlugin {
 
         async closeBundle() {
             try {
-                await spawnJigsawBuild(false);
+                await spawnJigsawBuild(pluginConfig.hotFile, false);
             } catch (error) {
                 console.error('Jigsaw build error:', error);
             }
@@ -316,7 +326,7 @@ function resolveJigsawWatcherPlugin(pluginConfig: DefinedPluginConfig): JigsawPl
                     if (shouldReload(path)) {
                         const start = performance.now();
 
-                        await JigsawQueue.enqueue(() => spawnJigsawBuild());
+                        await JigsawQueue.enqueue(() => spawnJigsawBuild(pluginConfig.hotFile));
 
                         const end = performance.now();
 


### PR DESCRIPTION
When building with `npm run build`, the asset paths in `index.html` should *not* refer to the live hot module replacement server.

However, if the `hot` file exists as a result of a previous `npm run dev` preview, running `npm run build` will generate a `build_production/index.html` with links pointing to a local server:

```html
<script type="module" src="http://[::1]:5173/@vite/client"></script>
<link rel="stylesheet" href="http://[::1]:5173/source/_assets/css/main.css">
<script defer type="module" src="http://[::1]:5173/source/_assets/js/main.js"></script>
```

...instead of the expected root-relative URLs:

```html
<link rel="stylesheet" href="/assets/build/assets/main-B9OrvdD2.css">
<script defer type="module" src="/assets/build/assets/main-l0sNRNKZ.js"></script>
```

### Steps to replicate

* Run the following commands:

```sh
mkdir jigsaw-bug && cd jigsaw-bug
composer require tightenco/jigsaw
vendor/bin/jigsaw init
npm install
npm run dev
```

* Stop the dev server, then run:

```
npm run build
```

* Open `jigsaw-bug/build_production/index.html`

**Result:** Asset links point to the live server.
**Expected:** Asset links should be root-relative. The `@vite/client` asset should not be present.

### Fix 

This PR fixes the issue by deleting the `hot` file before the build.

This does not affect future `npm run dev` previews—the `hot` file will be regenerated automatically.

