### PR TITLE
Add npm publish workflow using OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish Packages
+
+on:
+  release:
+    types: [released]
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22.14.0'
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      # Ensure npm 11.5.1 or later is installed
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish


### PR DESCRIPTION
## Goal
Automate publishing `@tighten/jigsaw-vite-plugin` to npm whenever a GitHub Release is published using OIDC

## Required one-time setup on npmjs.com
Before this workflow can publish, register the trusted publisher on the package's [settings page](https://www.npmjs.com/package/@tighten/jigsaw-vite-plugin/access):
- Publisher: GitHub Actions
- Organization: `tighten`
- Repository: `jigsaw-vite-plugin`
- Workflow filename: `publish.yml`
- Environment: leave blank